### PR TITLE
Add initial Github Actions test setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: Wagtail Live CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - 'stable/**'
+
+  pull_request:
+
+jobs:
+  test-sqlite:
+    name: python${{ matrix.python }}-django-wagtail${{ matrix.wagtail }}-sqlite
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.8']
+        wagtail: ['2.11', '2.13']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox
+        run: |
+          python -m pip install tox
+      - name: Test
+        run: |
+          tox
+        env:
+          TOXENV: python${{ matrix.python }}-django-wagtail${{ matrix.wagtail }}
+
+  lint:
+    name: Lint ${{ matrix.toxenv }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.8"]
+        toxenv: ["black", "isort", "flake8"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox
+        run: |
+          python -m pip install tox
+      - name: Run ${{ matrix.toxenv }}
+        run: |
+          tox
+        env:
+          TOXENV: ${{ matrix.toxenv }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,20 @@
 [tox]
 skipsdist = True
 envlist = 
-    py38-django-wagtail{211,213}
+    python3.8-django-wagtail{2.11,2.13}
 
 basepython =
-    py38: python3.8
-    py39: python3.9
+    python3.8: python3.8
+    python3.9: python3.9
 
 [testenv]
+install_command = pip install -e ".[test]" -U {opts} {packages}
 commands = pytest {posargs}
 extras = test
 deps =
     pytest-django>=4.3.0,<5
-    wagtail211: wagtail>=2.11,<2.12
-    wagtail213: wagtail>=2.13,<2.14
+    wagtail2.11: wagtail>=2.11,<2.12
+    wagtail2.13: wagtail>=2.13,<2.14
 
 [testenv:isort]
 commands=isort --check-only --diff wagtail_live tests setup.py


### PR DESCRIPTION
Test on sqlite with Wagtail 2.11 and 2.13 with the latest supported Django version
I've changed the tox environment names to be more verbose as they are used in the Github Actions job name.

View the workflow on my fork: https://github.com/Stormheg/wagtail-live/runs/2792577120

~~Documentation builds will be added in a follow-up PR.~~ See https://github.com/wagtail/wagtail-live/pull/18