### PR TITLE
Add documentation builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+  # Only deploy when the relevant files have changed
+  paths:
+    - "**.md"
+    - "mkdocs.yml"
+    - "setup.py"
+  workflow_dispatch:
+jobs:
+  docs:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.8"
+
+    - name: Install dependencies
+      run: |
+        # Install dependencies
+        python -m pip install '.[docs]'
+
+    - name: Build & deploy documentation
+      run: |
+        # Assume the identity of the github actions bot
+        git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+        mkdocs gh-deploy --force


### PR DESCRIPTION
Automatically deploy documentation to GitHub Pages. Will only run when
relevant files have changed and there was a push to main.