### PR TITLE
Test with Django 2.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,15 @@ on:
 
 jobs:
   test-sqlite:
-    name: python${{ matrix.python }}-django-wagtail${{ matrix.wagtail }}-sqlite
+    name: ${{ matrix.toxenv }}-sqlite
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.8']
-        wagtail: ['2.12', '2.13']
+        include:
+          - toxenv: 'python3.8-django2.2-wagtail2.12'
+            python: 3.8
+          - toxenv: 'python3.9-django3.2-wagtail2.13'
+            python: 3.9
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python }}
@@ -30,7 +33,7 @@ jobs:
         run: |
           tox
         env:
-          TOXENV: python${{ matrix.python }}-django-wagtail${{ matrix.wagtail }}
+          TOXENV: ${{ matrix.toxenv }}
 
   lint:
     name: Lint ${{ matrix.toxenv }}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -55,7 +55,7 @@ ALLOWED_HOSTS = ["*"]
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "NAME": str(BASE_DIR / "db.sqlite3"),
     }
 }
 

--- a/tests/wagtail_live/test_models.py
+++ b/tests/wagtail_live/test_models.py
@@ -26,10 +26,12 @@ def test_live_page_mixin():
     assert LivePageMixin._meta.abstract is True
 
 
-def test_live_page_mixin_channel_id_is_optional():
+@pytest.mark.django_db
+def test_live_page_mixin_channel_id_is_optional(blog_page_factory):
     """channel_id field is optional."""
 
-    assert LivePageMixin.channel_id.field.blank is True
+    page = blog_page_factory(channel_id="", live_posts=[])
+    assert page.channel_id == ""
 
 
 def test_live_page_mixin_live_posts_is_optional():

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 skipsdist = True
 envlist = 
-    python3.8-django-wagtail{2.12,2.13}
+    python3.8-django2.2-wagtail2.12
+    python3.9-django3.2-wagtail2.13
 
 basepython =
     python3.8: python3.8
@@ -17,6 +18,8 @@ deps =
     wagtail-factories>=2.0.1,<3
     wagtail2.12: wagtail>=2.12,<2.13
     wagtail2.13: wagtail>=2.13,<2.14
+    django2.2: django>=2.2,<2.3
+    django3.2: django>=3.2,<3.3
     mock>=4.0.3,<5.0.0
     pytest-mock>=3.6.1,<3.7.0
 


### PR DESCRIPTION
I've added Django 2.2 to the tox env.

We now test these combinations:

1. 
- Wagtail 2.12
- Django 2.2
- Python 3.8
2.
- Wagtail 2.13
- Django 3.2
- Python 3.9