### PR TITLE
Add possibility to provide custom template for live posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,6 @@ db.sqlite3
 # Images
 images/
 original_images/
+media/
 
 .envrc

--- a/src/wagtail_live/blocks.py
+++ b/src/wagtail_live/blocks.py
@@ -1,5 +1,6 @@
 """ Block types and block constructors are defined in this module."""
 
+from django.conf import settings
 from wagtail.core.blocks import (
     BooleanBlock,
     CharBlock,
@@ -38,8 +39,11 @@ class LivePostBlock(StructBlock):
     )
     content = ContentBlock()
 
-    class Meta:
-        template = "wagtail_live/blocks/live_post.html"
+    def get_template(self, context=None):
+        """We override this method to allow a custom live block template."""
+
+        template = getattr(settings, "WAGTAIL_LIVE_BLOCK_TEMPLATE", "")
+        return template if template else "wagtail_live/blocks/live_post.html"
 
 
 def construct_text_block(text):

--- a/tests/wagtail_live/test_blocks.py
+++ b/tests/wagtail_live/test_blocks.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime
 
 import pytest
+from django.test import override_settings
 from wagtail.core.blocks import StreamValue, StructValue
 from wagtail.embeds.blocks import EmbedValue
 
@@ -45,6 +46,15 @@ def test_construct_live_post_block():
             "content": StreamValue(ContentBlock(), []),
         },
     )
+
+
+def test_get_live_post_template_default():
+    assert LivePostBlock().get_template() == "wagtail_live/blocks/live_post.html"
+
+
+@override_settings(WAGTAIL_LIVE_BLOCK_TEMPLATE="custom_template.html")
+def test_get_custom_live_post_template():
+    assert LivePostBlock().get_template() == "custom_template.html"
 
 
 def test_add_block_to_live_post_structvalue():


### PR DESCRIPTION
While building the demo site, I faced the need to customize the `live_post.html` template. 

I'm adding this PR to address this issue.

The only thing we ask the user is the first line of his custom live post template to start as `live_post.html` i.e:
```
<div class="live-post" data-post-id="{{block_id}}">
```

He can put whatever he wishes in the div.