### PR TITLE
Don't create a block for empty content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,6 @@ db.sqlite3
 # Images
 images/
 original_images/
+media/
 
 .envrc

--- a/src/wagtail_live/receivers.py
+++ b/src/wagtail_live/receivers.py
@@ -184,8 +184,11 @@ class BaseMessageReceiver:
 
         message_parts = message_text.split("\n")
         for text in message_parts:
-            block_type = ""
+            # Avoid creating a block for empty content
+            if not text:
+                continue
 
+            block_type = ""
             url = self.get_embed(text=text)
             if url:
                 block = construct_embed_block(url=url)

--- a/src/wagtail_live/receivers.py
+++ b/src/wagtail_live/receivers.py
@@ -185,6 +185,7 @@ class BaseMessageReceiver:
         message_parts = message_text.split("\n")
         for text in message_parts:
             # Avoid creating a block for empty content
+            text = text.strip()
             if not text:
                 continue
 

--- a/tests/wagtail_live/receivers/test_basemessagereceiver.py
+++ b/tests/wagtail_live/receivers/test_basemessagereceiver.py
@@ -76,8 +76,6 @@ def test_process_text(base_receiver, blog_page_factory):
     msg = (
         "Live Post Title"
         + "\n"
-        + ""
-        + "\n"
         + "Check out Wagtail"
         + "\n"
         + valid_embed
@@ -100,6 +98,33 @@ def test_process_text(base_receiver, blog_page_factory):
 
     assert post_content[-1].block_type == TEXT
     assert post_content[-1].value == "Have fun!"
+
+
+@pytest.mark.django_db
+def test_process_text_with_empty_content(base_receiver, blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": "2021-01-01T12:00:00",
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    live_post = page.get_live_post_by_index(live_post_index=0)
+
+    msg = "   "
+    base_receiver.process_text(live_post, msg)
+
+    # No block has been added
+    assert len(live_post.value["content"]) == 0
 
 
 # Abstract methods tests

--- a/tests/wagtail_live/receivers/test_basemessagereceiver.py
+++ b/tests/wagtail_live/receivers/test_basemessagereceiver.py
@@ -76,6 +76,8 @@ def test_process_text(base_receiver, blog_page_factory):
     msg = (
         "Live Post Title"
         + "\n"
+        + ""
+        + "\n"
         + "Check out Wagtail"
         + "\n"
         + valid_embed

--- a/tests/wagtail_live/receivers/test_webappreceiver.py
+++ b/tests/wagtail_live/receivers/test_webappreceiver.py
@@ -149,10 +149,10 @@ def test_add_message(blog_page_factory, webapp_receiver, message):
     assert len(content) == len(message_parts)
 
     assert content[0].block_type == TEXT
-    assert content[0].value == message_parts[0]
+    assert content[0].value == message_parts[0].strip()
 
     assert content[-1].block_type == TEXT
-    assert content[-1].value == message_parts[-1]
+    assert content[-1].value == message_parts[-1].strip()
 
 
 @pytest.mark.django_db
@@ -200,8 +200,8 @@ def test_change_message_wrong_channel(blog_page_factory, webapp_receiver, messag
 
     # live post content shouldn't change
     assert len(content) == 2
-    assert content[0].value == "Some content. "
-    assert content[-1].value == " More content here."
+    assert content[0].value == "Some content."
+    assert content[-1].value == "More content here."
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Currently, empty blocks can be added via the `BaseMessageReceiver` and it can cause trouble when we want to modify the page in the admin interface.
