### PR TITLE
Only handle `message_changed` and `message_deleted` subtypes

### DIFF
--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -88,16 +88,14 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
         """See base class."""
 
         message = event["event"]
-        if "subtype" in message and message["subtype"] == "message_changed":
-            self.change_message(message=message)
+        if subtype := message.get("subtype"):
+            if subtype == "message_changed":
+                self.change_message(message=message)
+            elif subtype == "message_deleted":
+                self.delete_message(message=message)
             return
 
-        elif "subtype" in message and message["subtype"] == "message_deleted":
-            self.delete_message(message=message)
-            return
-
-        else:
-            self.add_message(message=message)
+        self.add_message(message=message)
 
     def get_channel_id_from_message(self, message):
         """See base class."""

--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -88,7 +88,9 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
         """See base class."""
 
         message = event["event"]
-        if subtype := message.get("subtype"):
+
+        subtype = message.get("subtype")
+        if subtype:
             if subtype == "message_changed":
                 self.change_message(message=message)
             elif subtype == "message_deleted":

--- a/tests/wagtail_live/receivers/conftest.py
+++ b/tests/wagtail_live/receivers/conftest.py
@@ -352,3 +352,24 @@ def slack_edited_image_message():
         "event_id": "Ev024EUE74NA",
         "event_time": 1623326006,
     }
+
+
+@pytest.fixture
+def slack_channel_join_message():
+    return {
+        "token": "token",
+        "event": {
+            "type": "message",
+            "subtype": "channel_join",
+            "ts": "1625679165.004400",
+            "user": "tester",
+            "text": "<@tester> has joined the channel",
+            "inviter": "inviter",
+            "channel": "slack_channel",
+            "event_ts": "1625679165.004400",
+            "channel_type": "channel",
+        },
+        "type": "event_callback",
+        "event_id": "Ev026XPJ8TLP",
+        "event_time": 1625679165,
+    }

--- a/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
@@ -171,6 +171,20 @@ def test_dispatch_deleted_message(slack_receiver, slack_deleted_message, mocker)
     slack_receiver.delete_message.assert_called_once_with(message=message)
 
 
+def test_dispatch_other_subtype_message(
+    slack_receiver, slack_channel_join_message, mocker
+):
+    mocker.patch.object(slack_receiver, "add_message")
+    mocker.patch.object(slack_receiver, "change_message")
+    mocker.patch.object(slack_receiver, "delete_message")
+
+    slack_receiver.dispatch_event(event=slack_channel_join_message)
+
+    slack_receiver.add_message.assert_not_called()
+    slack_receiver.change_message.assert_not_called()
+    slack_receiver.delete_message.assert_not_called()
+
+
 def test_get_channel_id_from_message(slack_receiver, slack_message):
     message = slack_message["event"]
     channel_id = slack_receiver.get_channel_id_from_message(message=message)


### PR DESCRIPTION
Slack sends different types of message subtypes.

We only want to process added/edited/deleted messages.