### PR TITLE
Handle embed urls according to Slack formats

### DIFF
--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -176,6 +176,17 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
         return self.get_message_files(message=message["message"])
 
     def get_embed(self, text):
-        """Strips leading `<` and trailing `>` from Slack urls."""
+        """Slack sends url in this format:
+        <https://twitter.com/wagtail/|https://twitter.com/wagtail/>'
+        where the first part is the full url and the second part
+        represents the user's input.
+        """
 
-        return text[1:-1] if is_embed(text=text[1:-1]) else ""
+        # Check if the text provided is a Slack-like url
+        if text.startswith("<") and text.endswith(">"):
+            # Get the url resolved by Slack
+            url = text[1:-1].split("|")[0]
+            if is_embed(text=url):
+                return url
+
+        return ""

--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -180,6 +180,8 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
         <https://twitter.com/wagtail/|https://twitter.com/wagtail/>'
         where the first part is the full url and the second part
         represents the user's input.
+
+        See https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages
         """
 
         # Check if the text provided is a Slack-like url

--- a/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
@@ -327,10 +327,14 @@ def test_get_files_from_edited_message_if_no_files(
 
 
 def test_get_embed_if_embed(slack_receiver):
-    slack_embed_url = "<https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
+    slack_embed_url = (
+        "<https://www.youtube.com/watch?v=Cq3LOsf2kSY"
+        + "|"
+        + "https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
+    )
     got = slack_receiver.get_embed(text=slack_embed_url)
 
-    assert got == slack_embed_url[1:-1]
+    assert got == slack_embed_url[1:-1].split("|")[0]
 
 
 def test_get_embed_if_not_embed(slack_receiver):


### PR DESCRIPTION
[Here](https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages) is how Slack formats URLs when a message is retrieved via their API.

This PR handle slack urls according to the format.