### PR TITLE
Process text block

### DIFF
--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -205,13 +205,10 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
                 url, description = text[1:-1].split("|")
             except ValueError as exc:
                 error_msg = str(exc.args[0])
-                assert any(
-                    (
-                        "not enough values to unpack" in error_msg,
-                        "too many values to unpack" in error_msg,
-                    )
-                )
-                return text
+                if "not enough values to unpack" in error_msg:
+                    url = description = text[1:-1]
+                else:
+                    return text
 
             try:
                 validator = URLValidator()

--- a/src/wagtail_live/adapters/slack/receiver.py
+++ b/src/wagtail_live/adapters/slack/receiver.py
@@ -5,8 +5,9 @@ from hashlib import sha256
 
 import requests
 from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.files.base import ContentFile
+from django.core.validators import URLValidator
 from django.http import HttpResponse
 
 from wagtail_live.exceptions import RequestVerificationError
@@ -192,3 +193,32 @@ class SlackEventsAPIReceiver(BaseMessageReceiver, SlackWebhookMixin):
                 return url
 
         return ""
+
+    def parse_text(self, text):
+        """See base class. See also:
+        https://api.slack.com/reference/surfaces/formatting#links-in-retrieved-messages
+        """
+
+        # Check if the text provided is a Slack-like url
+        if text.startswith("<") and text.endswith(">"):
+            try:
+                url, description = text[1:-1].split("|")
+            except ValueError as exc:
+                error_msg = str(exc.args[0])
+                assert any(
+                    (
+                        "not enough values to unpack" in error_msg,
+                        "too many values to unpack" in error_msg,
+                    )
+                )
+                return text
+
+            try:
+                validator = URLValidator()
+                validator(url)
+            except ValidationError:
+                return text
+
+            return f"<a href='{url}'>{description}</a>"
+
+        return text

--- a/src/wagtail_live/receivers.py
+++ b/src/wagtail_live/receivers.py
@@ -231,6 +231,19 @@ class BaseMessageReceiver:
 
         return text if is_embed(text=text) else ""
 
+    def parse_text(self, text):
+        """Parses a raw text content according to the input source formatting rules.
+
+        Args:
+            text (str): a text
+
+        Returns:
+            (str) the actual content of the text.
+                Returns the text itself by default.
+        """
+
+        return text
+
     def process_text(self, live_post, message_text):
         """Processes the text of a message.
 
@@ -259,7 +272,8 @@ class BaseMessageReceiver:
                 block_type = EMBED
 
             else:
-                block = construct_text_block(text=text)
+                text_content = self.parse_text(text=text)
+                block = construct_text_block(text=text_content)
                 block_type = TEXT
 
             add_block_to_live_post(

--- a/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
@@ -348,18 +348,18 @@ def test_parse_text(slack_receiver):
     assert got == text
 
 
-def test_parse_text_valid_url_format(slack_receiver):
-    text = (
-        "<https://www.youtube.com/watch?v=Cq3LOsf2kSY"
-        "|"
-        "https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
-    )
+def test_parse_text_valid_url_format_1(slack_receiver):
+    text = "<http://example.com/|http://example.com/>"
     got = slack_receiver.parse_text(text=text)
 
-    assert got == (
-        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
-        "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>"
-    )
+    assert got == "<a href='http://example.com/'>http://example.com/</a>"
+
+
+def test_parse_text_valid_url_format_2(slack_receiver):
+    text = "<http://example.com/>"
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == "<a href='http://example.com/'>http://example.com/</a>"
 
 
 def test_parse_text_invalid_url_format_1(slack_receiver):

--- a/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
@@ -329,8 +329,8 @@ def test_get_files_from_edited_message_if_no_files(
 def test_get_embed_if_embed(slack_receiver):
     slack_embed_url = (
         "<https://www.youtube.com/watch?v=Cq3LOsf2kSY"
-        + "|"
-        + "https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
+        "|"
+        "https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
     )
     got = slack_receiver.get_embed(text=slack_embed_url)
 
@@ -341,25 +341,20 @@ def test_get_embed_if_not_embed(slack_receiver):
     assert slack_receiver.get_embed("Not embed") == ""
 
 
-def test_parse_text(slack_receiver):
-    text = "A regular text."
-    got = slack_receiver.parse_text(text=text)
-
-    assert got == text
-
-
 def test_parse_text_valid_url_format_1(slack_receiver):
-    text = "<http://example.com/|http://example.com/>"
+    text = "This message contains a URL <http://example.com/>."
     got = slack_receiver.parse_text(text=text)
 
-    assert got == "<a href='http://example.com/'>http://example.com/</a>"
+    assert got == (
+        "This message contains a URL <a href='http://example.com/'>http://example.com/</a>."
+    )
 
 
 def test_parse_text_valid_url_format_2(slack_receiver):
-    text = "<http://example.com/>"
+    text = "So does this one: <http://example.com|www.example.com>"
     got = slack_receiver.parse_text(text=text)
 
-    assert got == "<a href='http://example.com/'>http://example.com/</a>"
+    assert got == "So does this one: <a href='http://example.com'>www.example.com</a>"
 
 
 def test_parse_text_invalid_url_format_1(slack_receiver):
@@ -370,14 +365,14 @@ def test_parse_text_invalid_url_format_1(slack_receiver):
 
 
 def test_parse_text_invalid_url_format_2(slack_receiver):
-    text = "<Some text|More text>"
+    text = "<http:Some text|More text>"
     got = slack_receiver.parse_text(text=text)
 
     assert got == text
 
 
 def test_parse_text_invalid_url_format_3(slack_receiver):
-    text = "<Some text|More text|More more text>"
+    text = "<http:Some text|More text|More more text>"
     got = slack_receiver.parse_text(text=text)
 
     assert got == text

--- a/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/test_slackeventsapireceiver.py
@@ -341,6 +341,48 @@ def test_get_embed_if_not_embed(slack_receiver):
     assert slack_receiver.get_embed("Not embed") == ""
 
 
+def test_parse_text(slack_receiver):
+    text = "A regular text."
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == text
+
+
+def test_parse_text_valid_url_format(slack_receiver):
+    text = (
+        "<https://www.youtube.com/watch?v=Cq3LOsf2kSY"
+        "|"
+        "https://www.youtube.com/watch?v=Cq3LOsf2kSY>"
+    )
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == (
+        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
+        "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>"
+    )
+
+
+def test_parse_text_invalid_url_format_1(slack_receiver):
+    text = "<Some text>"
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == text
+
+
+def test_parse_text_invalid_url_format_2(slack_receiver):
+    text = "<Some text|More text>"
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == text
+
+
+def test_parse_text_invalid_url_format_3(slack_receiver):
+    text = "<Some text|More text|More more text>"
+    got = slack_receiver.parse_text(text=text)
+
+    assert got == text
+
+
 @pytest.fixture
 def slack_page(blog_page_factory):
     """Creates a live page corresponding to slack_channel in Slack."""


### PR DESCRIPTION
Currently,if we receive a message like this from Slack:

```
This message contains a URL <http://example.com/>
```

Or like this one:

```
So does this one: <http://example.com|www.example.com>
```

The actual message that will be saved in the text block is:
```
<a href="http://example.com>www.example.com<a/>
```

Meaning that the text isn't saved at all.

This PR fixes that issue.