### PR TITLE
Add coverage support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,24 @@
+[run]
+branch = True
+include = wagtail_live/*
+omit = */migrations/*,*/tests/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,29 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
 
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.9']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          pip install -e '.[test]'
+      - name: Test
+        run: |
+          pytest --cov wagtail_live
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+
   lint:
     name: Lint ${{ matrix.toxenv }}
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:
 	flake8 src/wagtail_live tests setup.py
 
 test:
-	pytest
+	pytest --cov wagtail_live
 
 docs:
 	mkdocs serve -a 127.0.0.1:8080

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ test_requires = [
     "pytest>=6.2,<6.3",
     "pytest-cov>=2.12,<3",
     "pytest-django>=4.3.0,<5",
-    "pytest_factoryboy>=2.1.0,<3",
+    "pytest-factoryboy>=2.1.0,<3",
+    "pytest-mock>=3.6.1,<3.7.0",
+    "mock>=4.0.3,<5.0.0",
     "wagtail-factories>=2.0.1,<3",
 ]
 build_requires = [

--- a/tox.ini
+++ b/tox.ini
@@ -10,18 +10,13 @@ basepython =
 
 [testenv]
 install_command = pip install -e ".[test]" -U {opts} {packages}
-commands = pytest {posargs}
+commands = pytest --cov wagtail_live {posargs}
 extras = test
 deps =
-    pytest-django>=4.3.0,<5
-    pytest_factoryboy>=2.1.0,<3
-    wagtail-factories>=2.0.1,<3
     wagtail2.12: wagtail>=2.12,<2.13
     wagtail2.13: wagtail>=2.13,<2.14
     django2.2: django>=2.2,<2.3
     django3.2: django>=3.2,<3.3
-    mock>=4.0.3,<5.0.0
-    pytest-mock>=3.6.1,<3.7.0
 
 [testenv:isort]
 commands=isort --check-only --diff src/wagtail_live tests setup.py


### PR DESCRIPTION
Add Github Actions job to upload coverage to Codecov.

I've opted to keep coverage uploading out of tox. Like wagtail-localize has done here: https://github.com/wagtail/wagtail-localize/blob/main/.github/workflows/test.yml#L77