### PR TITLE
Use `save` instead of `save_revision`

### DIFF
--- a/src/wagtail_live/models.py
+++ b/src/wagtail_live/models.py
@@ -55,6 +55,7 @@ class LivePageMixin(models.Model):
         """Update last_updated_at when the page is modified on the admin interface."""
 
         self.last_updated_at = timezone.now()
+        super().clean()
 
     def _get_live_post_index(self, message_id):
         """Retrieves the index of a live post.

--- a/src/wagtail_live/models.py
+++ b/src/wagtail_live/models.py
@@ -51,6 +51,11 @@ class LivePageMixin(models.Model):
 
         return self.last_updated_at.timestamp()
 
+    def clean(self):
+        """Update last_updated_at when the page is modified on the admin interface."""
+
+        self.last_updated_at = timezone.now()
+
     def _get_live_post_index(self, message_id):
         """Retrieves the index of a live post.
 
@@ -123,8 +128,9 @@ class LivePageMixin(models.Model):
 
         # Insert to keep posts sorted by time
         self.live_posts.insert(lp_index, ("live_post", live_post))
+
         self.last_updated_at = post_created_at
-        self.save_revision().publish()
+        self.save(clean=False)
 
     def delete_live_post(self, message_id):
         """Deletes the live post corresponding to message_id.
@@ -141,8 +147,9 @@ class LivePageMixin(models.Model):
             raise KeyError
 
         del self.live_posts[live_post_index]
+
         self.last_updated_at = timezone.now()
-        self.save_revision().publish()
+        self.save(clean=False)
 
     def update_live_post(self, live_post):
         """Updates a live post when it has been edited.
@@ -151,7 +158,7 @@ class LivePageMixin(models.Model):
         """
 
         live_post.value["modified"] = self.last_updated_at = timezone.now()
-        self.save_revision().publish()
+        self.save(clean=False)
 
     def get_updates_since(self, last_update_ts):
         """Retrieves new updates since a given timestamp value.

--- a/tests/wagtail_live/test_models.py
+++ b/tests/wagtail_live/test_models.py
@@ -325,37 +325,6 @@ def test_live_page_mixin_update_live_post(blog_page_factory):
 
 
 @pytest.mark.django_db
-def test_live_mixin_update_live_posts_creates_revisions(blog_page_factory):
-    """Revisions are created when a live post is added, edited or deleted."""
-
-    page = blog_page_factory(channel_id="some-id")
-    assert page.revisions.count() == 0
-
-    # ADD
-    live_post = construct_live_post_block(message_id="some-id", created=now())
-    page.add_live_post(live_post=live_post)
-    assert page.revisions.count() == 1
-    # The revision is published
-    page.refresh_from_db()
-    assert page.get_latest_revision() == page.live_revision
-
-    # EDIT
-    live_post = page.get_live_post_by_index(live_post_index=0)
-    page.update_live_post(live_post=live_post)
-    assert page.revisions.count() == 2
-    # The revision is published
-    page.refresh_from_db()
-    assert page.get_latest_revision() == page.live_revision
-
-    # DELETE
-    page.delete_live_post(message_id="some-id")
-    assert page.revisions.count() == 3
-    # The revision is published
-    page.refresh_from_db()
-    assert page.get_latest_revision() == page.live_revision
-
-
-@pytest.mark.django_db
 def test_edit_live_posts_updates_last_updated_at(blog_page_factory):
     """last_updated_at is updated when a live post is added, edited or deleted."""
 


### PR DESCRIPTION
Now that we don't use `latest_revision created_at`, we can use save.

I added `clean=False` to LivePageMixin methods and overrode its `clean` method.

The idea is that we don't want to reset `last_updated_at` if we already set it ourselves, but we want it to be automatically set if a page is modified via the admin interface.

I don't know if this is the best solution. I also imagined adding a signal when a `LivePostBlock` is modified via the admin so we have more control on the `last_updated_at` field?

The general idea is that we want `last_updated_at` to match the most exactly possible the last date and time when a message has been added/edited/deleted via receivers or via the admin interface.