### PR TITLE
Add extra attributes to `LivePageMixin` to help track changes made in the Admin UI

### DIFF
--- a/src/wagtail_live/blocks.py
+++ b/src/wagtail_live/blocks.py
@@ -1,6 +1,5 @@
 """ Block types and block constructors are defined in this module."""
 
-from django.utils.timezone import now
 from wagtail.core.blocks import (
     BooleanBlock,
     CharBlock,
@@ -41,12 +40,6 @@ class LivePostBlock(StructBlock):
 
     class Meta:
         template = "wagtail_live/blocks/live_post.html"
-
-    def clean(self, value):
-        """Update modified field when a block is modified via the admin interface."""
-
-        value["modified"] = now()
-        return super().clean(value)
 
 
 def construct_text_block(text):

--- a/src/wagtail_live/models.py
+++ b/src/wagtail_live/models.py
@@ -56,16 +56,14 @@ class LivePageMixin(models.Model):
 
         super().__init__(*args, **kwargs)
         self._previous_posts = self.live_posts
-        self._synced = False
-        self._has_changed = False
+        self._synced = self._has_changed = False
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)
 
         # Update extra attributes when the page is saved
         self._previous_posts = self.live_posts
-        self._synced = False
-        self._has_changed = False
+        self._synced = self._has_changed = False
         return result
 
     def clean(self):

--- a/tests/wagtail_live/test_blocks.py
+++ b/tests/wagtail_live/test_blocks.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 
 import pytest
-from django.utils.timezone import now
 from wagtail.core.blocks import StreamValue, StructValue
 from wagtail.embeds.blocks import EmbedValue
 
@@ -46,27 +45,6 @@ def test_construct_live_post_block():
             "content": StreamValue(ContentBlock(), []),
         },
     )
-
-
-def test_update_modified_field():
-    live_post_block = construct_live_post_block(
-        message_id="1234",
-        created=datetime(1970, 1, 1, 12, 00),
-    )
-    assert live_post_block["modified"] is None
-
-    live_post_block["content"] = StreamValue(ContentBlock(), [("text", "Some text")])
-    live_post_block.block.clean(live_post_block)
-
-    last_modified = live_post_block["modified"]
-    diff = now() - last_modified
-    assert diff.total_seconds() == pytest.approx(0.0, abs=1)
-
-    live_post_block["content"] = StreamValue(
-        ContentBlock(), [("text", "Some text modified")]
-    )
-    live_post_block.block.clean(live_post_block)
-    assert live_post_block["modified"] > last_modified
 
 
 def test_add_block_to_live_post_structvalue():

--- a/tests/wagtail_live/test_models.py
+++ b/tests/wagtail_live/test_models.py
@@ -455,3 +455,393 @@ def test_get_updates_since_hidden_posts(blog_page_factory):
     assert "3" in updated_posts
     assert "2" not in updated_posts
     assert "1" not in updated_posts
+
+
+@pytest.mark.django_db
+def test_clean_live_page_1(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": False,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_posts
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at > last_updated_at
+    last_updated_at = page.last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="some-id").value["modified"]
+        == last_updated_at
+    )
+    assert (
+        page.get_live_post_by_message_id(message_id="other-id").value["modified"]
+        is None
+    )
+
+
+@pytest.mark.django_db
+def test_clean_live_page_2(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_posts
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at > last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="other-id").value["modified"]
+        is None
+    )
+
+
+@pytest.mark.django_db
+def test_clean_live_page_3(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "new-id",
+                "value": {
+                    "message_id": "new-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_posts
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at > last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="other-id").value["modified"]
+        is None
+    )
+    assert (
+        page.get_live_post_by_message_id(message_id="new-id").value["modified"] is None
+    )
+
+
+@pytest.mark.django_db
+def test_clean_live_page_4(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_post = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": False,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": False,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_post
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at > last_updated_at
+    last_updated_at = page.last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="some-id").value["modified"]
+        == last_updated_at
+    )
+    assert (
+        page.get_live_post_by_message_id(message_id="other-id").value["modified"]
+        is None
+    )
+
+
+@pytest.mark.django_db
+def test_clean_live_page_5(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_posts
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at == last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="some-id").value["modified"] is None
+    )
+    assert (
+        page.get_live_post_by_message_id(message_id="other-id").value["modified"]
+        is None
+    )
+
+
+@pytest.mark.django_db
+def test_clean_live_page_6(blog_page_factory):
+    live_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+            {
+                "type": "live_post",
+                "id": "other-id",
+                "value": {
+                    "message_id": "other-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page = blog_page_factory(channel_id="some-id", live_posts=live_posts)
+    last_updated_at = page.last_updated_at
+
+    new_posts = json.dumps(
+        [
+            {
+                "type": "live_post",
+                "id": "some-id",
+                "value": {
+                    "message_id": "some-id",
+                    "created": "2021-01-01T12:00:00",
+                    "modified": None,
+                    "show": True,
+                    "content": [],
+                },
+            },
+        ]
+    )
+    page.live_posts = new_posts
+    page.clean()
+    page.save()
+
+    assert page.last_updated_at > last_updated_at
+    assert (
+        page.get_live_post_by_message_id(message_id="some-id").value["modified"] is None
+    )


### PR DESCRIPTION
From #72, when a post is modified via the admin interface, all other posts in the page will also have their `modified` field updated. This isn't the expected behaviour.

This PR adds some helper attributes to track posts that have been changed in the admin and only update the `modified` field of those edited posts. Posts that haven't changed shouldn't have their `modified` field changed.

The `last_updated_at` field of `LivePageMixin` now reflects more accurately the date and time when a message has been added/edited/deleted via a receiver or via the admin.