### PR TITLE
Telegram webhook receiver

### DIFF
--- a/src/wagtail_live/adapters/telegram/__init__.py
+++ b/src/wagtail_live/adapters/telegram/__init__.py
@@ -1,0 +1,14 @@
+from .receiver import TelegramWebhookMixin, TelegramWebhookReceiver
+from .utils import (
+    get_base_telegram_url,
+    get_telegram_bot_token,
+    get_telegram_webhook_url,
+)
+
+__all__ = [
+    "TelegramWebhookMixin",
+    "TelegramWebhookReceiver",
+    "get_telegram_bot_token",
+    "get_telegram_webhook_url",
+    "get_base_telegram_url",
+]

--- a/src/wagtail_live/adapters/telegram/receiver.py
+++ b/src/wagtail_live/adapters/telegram/receiver.py
@@ -1,0 +1,273 @@
+import logging
+
+import requests
+from django.core.files.base import ContentFile
+
+from wagtail_live.exceptions import RequestVerificationError, WebhookSetupError
+from wagtail_live.receivers import BaseMessageReceiver, WebhookReceiverMixin
+from wagtail_live.utils import is_embed
+
+from .utils import (
+    get_base_telegram_url,
+    get_telegram_bot_token,
+    get_telegram_webhook_url,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class TelegramWebhookMixin(WebhookReceiverMixin):
+    """Telegram WebhookMixin."""
+
+    url_path = "telegram/events/<str:token>/"
+    url_name = "telegram_events_handler"
+
+    def verify_request(self, request, body, token, *args, **kwargs):
+        """See base class."""
+
+        if token != get_telegram_bot_token():
+            raise RequestVerificationError
+
+    @classmethod
+    def webhook_connection_set(cls):
+        """See base class."""
+
+        response = requests.get(get_base_telegram_url() + "getWebhookInfo")
+        if response.ok:
+            # Ensure that the webhook is set with the correct URL
+            payload = response.json()
+            return (
+                payload["ok"] and payload["result"]["url"] == get_telegram_webhook_url()
+            )
+        return False
+
+    @classmethod
+    def set_webhook(cls):
+        """Sets webhook connection with Telegram's API"""
+
+        response = requests.get(
+            get_base_telegram_url() + "setWebhook",
+            params={
+                "url": get_telegram_webhook_url(),
+                "allowed_updates": [
+                    "message",
+                    "edited_message",
+                    "channel_post",
+                    "edited_channel_post",
+                ],
+            },
+        )
+        payload = response.json()
+
+        if not response.ok or not payload["ok"]:
+            raise WebhookSetupError(
+                "Failed to set Webhook connection with Telegram's API. "
+                + f"{payload['description']}"
+            )
+
+
+class TelegramWebhookReceiver(TelegramWebhookMixin, BaseMessageReceiver):
+    """Telegram webhook receiver."""
+
+    def dispatch_event(self, event):
+        """Telegram doesn't send an update when a message is deleted.
+        See base class.
+        """
+
+        for edit_type in ["edited_message", "edited_channel_post"]:
+            if edit_type in event:
+                self.change_message(message=event.get(edit_type))
+                return
+
+        message = event.get("message") or event.get("channel_post")
+        if "media_group_id" in message:
+            try:
+                self.add_image_to_message(message=message)
+                return
+            except KeyError:
+                pass
+
+        if "entities" in message and message["entities"][0]["type"] == "bot_command":
+            self.handle_bot_command(message=message)
+            return
+
+        self.add_message(message=message)
+
+    def add_image_to_message(self, message):
+        """Telegram sends images uploaded in a message one by one."""
+
+        channel_id = self.get_channel_id_from_message(message=message)
+        try:
+            live_page = self.get_live_page_from_channel_id(channel_id=channel_id)
+        except self.model.DoesNotExist:
+            return
+
+        message_id = self.get_message_id_from_message(message=message)
+        live_post = live_page.get_live_post_by_message_id(message_id=message_id)
+
+        files = self.get_message_files(message=message)
+        self.process_files(live_post=live_post.value, files=files)
+
+        live_page.update_live_post(live_post=live_post)
+
+    def handle_bot_command(self, message):
+        """Handles the following bot commands:
+        /get_chat_id: returns the id of the current chat.
+        """
+
+        command = message["entities"][0]
+        start = command["offset"]
+        end = start + command["length"]
+        command_text = message["text"][start:end]
+
+        if command_text == "/get_chat_id":
+            chat_id = self.get_channel_id_from_message(message=message)
+            response = requests.get(
+                get_base_telegram_url() + "sendMessage",
+                params={
+                    "chat_id": chat_id,
+                    "text": chat_id,
+                },
+            )
+
+            payload = response.json()
+            if not payload["ok"]:
+                logger.error(payload["description"])
+
+    def get_channel_id_from_message(self, message):
+        """See base class."""
+
+        # Since live posts aren't cleaned when they are added via a receiver,
+        # we make sure at this level that we return the correct types.
+        return str(message["chat"]["id"])
+
+    def get_message_id_from_message(self, message):
+        """Messages containing multiple images have a media_group_id attribute.
+        See base class.
+        """
+
+        msg_id = message.get("media_group_id") or message.get("message_id")
+        return str(msg_id)
+
+    def get_message_text(self, message):
+        """See base class."""
+
+        # Telegram parses the text of a message before sending it.
+        # The result can be found in the message's "entities".
+        return {
+            "text": message.get("text") or message.get("caption") or "",
+            "entities": message.get("entities", []),
+        }
+
+    def process_text(self, live_post, message_text):
+        """Use the message entities to convert links.
+        A raw link isn't converted by Telegram.
+        A link with a description is sent as a `text_link` entity.
+        See base class.
+        """
+
+        text = message_text["text"]
+        len_text = len(text)
+
+        cumulated_offset = 0
+        entities = message_text["entities"]
+        for entity in entities:
+            url = ""
+            offset = int(entity["offset"]) + cumulated_offset
+            length = int(entity["length"])
+            end = offset + length
+
+            if entity["type"] == "url":
+                url = description = text[offset:end]
+                if is_embed(url):
+                    # Check if this can match an embed block, if so no conversion happens.
+                    if end == len_text or (
+                        len_text > end + 1 and text[end : end + 1] == "\n"  # noqa
+                    ):
+                        if offset == 0 or text[offset - 1 : offset] == "\n":  # noqa
+                            # This is an embed block
+                            continue
+
+            if entity["type"] == "text_link":
+                url = entity["url"]
+                description = text[offset:end]
+
+            if url:
+                link = f"<a href='{url}'>{description}</a>"
+                text = text[:offset] + link + text[end:]
+                len_added = len(link) - length
+                cumulated_offset += len_added
+                len_text += len_added
+
+        return super().process_text(live_post=live_post, message_text=text)
+
+    def get_file_path(self, file_id):
+        """Retrieves the file_path of a Telegram file.
+        The file_path is necessary to have more infos about the image and download it.
+
+        Args:
+            file_id (str): Id of the file to download.
+
+        Returns:
+            (str) The file_path property of the file as sent by Telegram.
+        """
+
+        response = requests.get(
+            get_base_telegram_url() + "getFile", params={"file_id": file_id}
+        )
+        return response.json()["result"]["file_path"]
+
+    def get_message_files(self, message):
+        """See base class."""
+
+        if "photo" in message:
+            # Choose original photo which is the last of the list
+            photo = message["photo"][-1]
+            photo["file_path"] = self.get_file_path(file_id=photo["file_id"])
+            return [photo]
+        return []
+
+    def get_image_title(self, image):
+        """See base class."""
+
+        return image["file_path"].split("/")[-1].split(".")[0]
+
+    def get_image_name(self, image):
+        """See base class."""
+
+        return image["file_path"].split("/")[-1]
+
+    def get_image_mimetype(self, image):
+        """See base class."""
+
+        mimetype = image["file_path"].split("/")[-1].split(".")[-1]
+        return "jpeg" if mimetype == "jpg" else mimetype
+
+    def get_image_content(self, image):
+        """See base class."""
+
+        file_path = image["file_path"]
+        response = requests.get(
+            f"https://api.telegram.org/file/bot{get_telegram_bot_token()}/{file_path}"
+        )
+        return ContentFile(response.content)
+
+    def get_image_dimensions(self, image):
+        """See base class."""
+
+        return image["width"], image["height"]
+
+    def get_message_id_from_edited_message(self, message):
+        """See base class."""
+
+        return self.get_message_id_from_message(message=message)
+
+    def get_message_text_from_edited_message(self, message):
+        """See base class."""
+
+        return self.get_message_text(message=message)
+
+    def get_message_files_from_edited_message(self, message):
+        """See base class."""
+
+        return self.get_message_files(message=message)

--- a/src/wagtail_live/adapters/telegram/utils.py
+++ b/src/wagtail_live/adapters/telegram/utils.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def get_telegram_bot_token():
     """Retrieves user's telegram bot token.
 
@@ -23,7 +23,7 @@ def get_telegram_bot_token():
     return bot_token
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def get_telegram_webhook_url():
     """Retrieves the webhook url which Telegram sends new updates to.
 
@@ -48,7 +48,7 @@ def get_telegram_webhook_url():
     )
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=1)
 def get_base_telegram_url():
     """Returns the base URL to use when calling Telegram's API."""
 

--- a/src/wagtail_live/adapters/telegram/utils.py
+++ b/src/wagtail_live/adapters/telegram/utils.py
@@ -1,10 +1,10 @@
-from functools import cache
+from functools import lru_cache
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_telegram_bot_token():
     """Retrieves user's telegram bot token.
 
@@ -23,7 +23,7 @@ def get_telegram_bot_token():
     return bot_token
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_telegram_webhook_url():
     """Retrieves the webhook url which Telegram sends new updates to.
 
@@ -48,7 +48,7 @@ def get_telegram_webhook_url():
     )
 
 
-@cache
+@lru_cache(maxsize=None)
 def get_base_telegram_url():
     """Returns the base URL to use when calling Telegram's API."""
 

--- a/src/wagtail_live/adapters/telegram/utils.py
+++ b/src/wagtail_live/adapters/telegram/utils.py
@@ -1,0 +1,55 @@
+from functools import cache
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+
+@cache
+def get_telegram_bot_token():
+    """Retrieves user's telegram bot token.
+
+    Returns:
+        (str) telegram bot token.
+
+    Raises:
+        (ImproperlyConfigured) if the telegram bot token isn't specified in settings.
+    """
+
+    bot_token = getattr(settings, "TELEGRAM_BOT_TOKEN", "")
+    if not bot_token:
+        raise ImproperlyConfigured(
+            "Specify TELEGRAM_BOT_TOKEN if you intend to use Telegram as input source."
+        )
+    return bot_token
+
+
+@cache
+def get_telegram_webhook_url():
+    """Retrieves the webhook url which Telegram sends new updates to.
+
+    Returns:
+        (str) a URL.
+
+    Raises:
+        (ImproperlyConfigured) if the telegram webhook url isn't specified in settings.
+    """
+
+    base_webhook_url = getattr(settings, "TELEGRAM_WEBHOOK_URL", "")
+    if not base_webhook_url:
+        raise ImproperlyConfigured(
+            "Specify TELEGRAM_WEBHOOK_URL if you intend to use Telegram as input source."
+        )
+
+    if base_webhook_url.endswith("/"):
+        base_webhook_url = base_webhook_url[:-1]
+
+    return (
+        f"{base_webhook_url}/wagtail_live/telegram/events/{get_telegram_bot_token()}/"
+    )
+
+
+@cache
+def get_base_telegram_url():
+    """Returns the base URL to use when calling Telegram's API."""
+
+    return f"https://api.telegram.org/bot{get_telegram_bot_token()}/"

--- a/src/wagtail_live/receivers.py
+++ b/src/wagtail_live/receivers.py
@@ -20,7 +20,7 @@ from .blocks import (
     construct_live_post_block,
     construct_text_block,
 )
-from .exceptions import RequestVerificationError, WebhookSetupError
+from .exceptions import RequestVerificationError
 from .utils import SUPPORTED_MIME_TYPES, get_live_page_model, is_embed
 
 logger = logging.getLogger(__name__)
@@ -493,10 +493,7 @@ class WebhookReceiverMixin(View):
         """
 
         if not cls.webhook_connection_set():
-            try:
-                cls.set_webhook()
-            except WebhookSetupError:
-                raise
+            cls.set_webhook()
 
         return [
             path(cls.url_path, cls.as_view(), name=cls.url_name),

--- a/src/wagtail_live/utils.py
+++ b/src/wagtail_live/utils.py
@@ -1,6 +1,7 @@
 """Wagtail Live utils"""
 
 import re
+from functools import cache
 from importlib import import_module
 
 from django.conf import settings
@@ -121,6 +122,7 @@ def get_polling_interval():
     return getattr(settings, "WAGTAIL_LIVE_POLLING_INTERVAL", 3000)
 
 
+@cache
 def is_embed(text):
     """Checks if a text is a link to embed.
 

--- a/src/wagtail_live/utils.py
+++ b/src/wagtail_live/utils.py
@@ -1,7 +1,7 @@
 """Wagtail Live utils"""
 
 import re
-from functools import cache
+from functools import lru_cache
 from importlib import import_module
 
 from django.conf import settings
@@ -122,7 +122,7 @@ def get_polling_interval():
     return getattr(settings, "WAGTAIL_LIVE_POLLING_INTERVAL", 3000)
 
 
-@cache
+@lru_cache(maxsize=None)
 def is_embed(text):
     """Checks if a text is a link to embed.
 

--- a/tests/wagtail_live/receivers/telegram/conftest.py
+++ b/tests/wagtail_live/receivers/telegram/conftest.py
@@ -300,3 +300,47 @@ def telegram_message_with_entities():
             ],
         },
     }
+
+
+@pytest.fixture
+def telegram_bot_command():
+    return {
+        "update_id": 11,
+        "message": {
+            "message_id": 11,
+            "from": {
+                "id": 100,
+                "is_bot": False,
+                "first_name": "Tester",
+            },
+            "chat": {
+                "id": 100,
+                "first_name": "Tester",
+            },
+            "date": 1626688645,
+            "text": "/get_chat_id",
+            "entities": [{"offset": 0, "length": 12, "type": "bot_command"}],
+        },
+    }
+
+
+@pytest.fixture
+def telegram_bot_other_command():
+    return {
+        "update_id": 12,
+        "message": {
+            "message_id": 12,
+            "from": {
+                "id": 100,
+                "is_bot": False,
+                "first_name": "Tester",
+            },
+            "chat": {
+                "id": 100,
+                "first_name": "Tester",
+            },
+            "date": 1626688645,
+            "text": "/other_command",
+            "entities": [{"offset": 0, "length": 15, "type": "bot_command"}],
+        },
+    }

--- a/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
+++ b/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
@@ -1,0 +1,540 @@
+from datetime import datetime
+
+import pytest
+import requests
+from django.core.files.base import ContentFile
+from django.test import override_settings
+from django.urls import resolve, reverse
+
+from tests.utils import get_test_image_file, reload_urlconf
+from wagtail_live.adapters.telegram import get_base_telegram_url
+from wagtail_live.adapters.telegram.receiver import (
+    TelegramWebhookMixin,
+    TelegramWebhookReceiver,
+)
+from wagtail_live.blocks import construct_live_post_block
+from wagtail_live.exceptions import WebhookSetupError
+from wagtail_live.receivers import EMBED, IMAGE, BaseMessageReceiver
+
+
+@pytest.fixture
+def telegram_receiver():
+    return TelegramWebhookReceiver()
+
+
+def test_telegram_receiver_instance(telegram_receiver):
+    assert isinstance(telegram_receiver, BaseMessageReceiver)
+    assert isinstance(telegram_receiver, TelegramWebhookMixin)
+
+
+# TelegramWebhookMixin methods
+
+
+class ResponseMock:
+    def __init__(self, ok, json_data):
+        self.ok = ok
+        self.json_data = json_data
+
+    def ok(self):
+        return self.ok
+
+    def json(self):
+        return self.json_data
+
+
+@pytest.fixture
+@override_settings(
+    WAGTAIL_LIVE_RECEIVER="wagtail_live.adapters.telegram.TelegramWebhookReceiver"
+)
+def reload_urls(mocker):
+    mocker.patch.object(
+        TelegramWebhookReceiver, "webhook_connection_set", return_value=True
+    )
+    reload_urlconf()
+    resolved = resolve("/wagtail_live/telegram/events/telegram-token/")
+
+    assert resolved.url_name == "telegram_events_handler"
+
+
+@pytest.fixture
+def telegram_overrides():
+    with override_settings(
+        TELEGRAM_BOT_TOKEN="telegram-token", TELEGRAM_WEBHOOK_URL="www.webhook.com"
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("telegram_overrides")
+class TestTelegramwebhookMixin:
+    def test_verify_request(self, client, mocker, reload_urls):
+        mocker.patch.object(
+            TelegramWebhookReceiver, "dispatch_event", return_value=None
+        )
+        response = client.post(
+            reverse("telegram_events_handler", kwargs={"token": "telegram-token"}),
+            content_type="application/json",
+            data={},
+        )
+        assert response.status_code == 200
+
+    def test_verify_request_bad_token(self, client, reload_urls):
+        response = client.post(
+            reverse(
+                "telegram_events_handler", kwargs={"token": "wrong-telegram-token"}
+            ),
+            content_type="application/json",
+            data={},
+        )
+
+        assert response.status_code == 403
+        assert "Request verification failed." in response.content.decode()
+
+    def test_webhook_connection_set(self, mocker):
+        json_data = {
+            "ok": True,
+            "result": {
+                "url": "www.webhook.com/wagtail_live/telegram/events/telegram-token/",
+            },
+        }
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+        )
+
+        assert TelegramWebhookReceiver.webhook_connection_set() is True
+
+    def test_webhook_connection_set_response_not_ok(self, mocker):
+        json_data = {
+            "ok": True,
+            "result": {
+                "url": "www.webhook.com/wagtail_live/telegram/events/telegram-token/",
+            },
+        }
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=False, json_data=json_data)
+        )
+
+        assert TelegramWebhookReceiver.webhook_connection_set() is False
+
+    def test_webhook_connection_set_result_not_ok(self, mocker):
+        json_data = {
+            "ok": False,
+            "result": {
+                "url": "www.webhook.com/wagtail_live/telegram/events/telegram-token/",
+            },
+        }
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+        )
+
+        assert TelegramWebhookReceiver.webhook_connection_set() is False
+
+    def test_webhook_connection_set_different_webhook_got(self, mocker):
+        json_data = {
+            "ok": True,
+            "result": {
+                "url": "www.different-url.com",
+            },
+        }
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+        )
+
+        assert TelegramWebhookReceiver.webhook_connection_set() is False
+
+    def test_set_webhook(self, mocker):
+        json_data = {"ok": True}
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+        )
+
+        assert TelegramWebhookReceiver.set_webhook() is None
+
+    def test_set_webhook_raises_error(self, mocker):
+        json_data = {"ok": False, "result": True, "description": "Webhook wasn't set"}
+        mocker.patch.object(
+            requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+        )
+
+        expected_err = (
+            "Failed to set Webhook connection with Telegram's API. Webhook wasn't set"
+        )
+        with pytest.raises(WebhookSetupError, match=expected_err):
+            TelegramWebhookReceiver.set_webhook()
+
+
+# BaseMessageReceiver methods
+
+
+def test_dispatch_new_message(telegram_receiver, telegram_message, mocker):
+    mocker.patch.object(telegram_receiver, "add_message")
+    telegram_receiver.dispatch_event(event=telegram_message)
+
+    message = telegram_message["message"]
+    telegram_receiver.add_message.assert_called_once_with(message=message)
+
+
+def test_dispatch_new_channel_post(telegram_receiver, telegram_channel_post, mocker):
+    mocker.patch.object(telegram_receiver, "add_message")
+    telegram_receiver.dispatch_event(event=telegram_channel_post)
+
+    message = telegram_channel_post["channel_post"]
+    telegram_receiver.add_message.assert_called_once_with(message=message)
+
+
+def test_dispatch_edited_message(telegram_receiver, telegram_edited_message, mocker):
+    mocker.patch.object(telegram_receiver, "change_message")
+    telegram_receiver.dispatch_event(event=telegram_edited_message)
+
+    message = telegram_edited_message["edited_message"]
+    telegram_receiver.change_message.assert_called_once_with(message=message)
+
+
+def test_dispatch_edited_channel_post(
+    telegram_receiver, telegram_edited_channel_post, mocker
+):
+    mocker.patch.object(telegram_receiver, "change_message")
+    telegram_receiver.dispatch_event(event=telegram_edited_channel_post)
+
+    message = telegram_edited_channel_post["edited_channel_post"]
+    telegram_receiver.change_message.assert_called_once_with(message=message)
+
+
+def test_dispatch_bot_command(telegram_receiver, telegram_bot_command, mocker):
+    mocker.patch.object(telegram_receiver, "handle_bot_command")
+    telegram_receiver.dispatch_event(event=telegram_bot_command)
+
+    message = telegram_bot_command["message"]
+    telegram_receiver.handle_bot_command.assert_called_once_with(message=message)
+
+
+def test_handle_bot_command(telegram_receiver, telegram_bot_command, mocker):
+    mocker.patch.object(
+        requests, "get", return_value=ResponseMock(ok=True, json_data={"ok": True})
+    )
+    message = telegram_bot_command["message"]
+    chat_id = telegram_receiver.get_channel_id_from_message(message)
+
+    assert telegram_receiver.handle_bot_command(message=message) is None
+    requests.get.assert_called_once_with(
+        get_base_telegram_url() + "sendMessage",
+        params={
+            "chat_id": chat_id,
+            "text": chat_id,
+        },
+    )
+
+
+def test_handle_other_bot_commands(
+    telegram_receiver, telegram_bot_other_command, mocker
+):
+    mocker.patch.object(requests, "get", return_value=None)
+    message = telegram_bot_other_command["message"]
+
+    assert telegram_receiver.handle_bot_command(message=message) is None
+    requests.get.assert_not_called()
+
+
+def test_handle_bot_command_error(
+    telegram_receiver, telegram_bot_command, mocker, caplog
+):
+    json_data = {"ok": False, "description": "Failed sending message"}
+    mocker.patch.object(
+        requests, "get", return_value=ResponseMock(ok=True, json_data=json_data)
+    )
+
+    message = telegram_bot_command["message"]
+    telegram_receiver.handle_bot_command(message=message)
+    assert caplog.messages[0] == "Failed sending message"
+
+
+def test_get_channel_id_from_message(telegram_receiver, telegram_message):
+    message = telegram_message["message"]
+    channel_id = telegram_receiver.get_channel_id_from_message(message=message)
+
+    assert channel_id == str(message["chat"]["id"])
+
+
+def test_get_message_id_from_message(telegram_receiver, telegram_message):
+    message = telegram_message["message"]
+    message_id = telegram_receiver.get_message_id_from_message(message=message)
+
+    assert message_id == str(message["message_id"])
+
+
+def test_get_message_id_from_media_message(telegram_receiver, telegram_media_message_1):
+    message = telegram_media_message_1["message"]
+    message_id = telegram_receiver.get_message_id_from_message(message=message)
+
+    assert message_id == str(message["media_group_id"])
+
+
+def test_get_message_text(telegram_receiver, telegram_message):
+    message = telegram_message["message"]
+    message_text = telegram_receiver.get_message_text(message=message)
+
+    assert message_text == {"text": message["text"], "entities": []}
+
+
+def test_get_message_text_image_message(telegram_receiver, telegram_image_message):
+    message = telegram_image_message["message"]
+    message_text = telegram_receiver.get_message_text(message=message)
+
+    assert message_text == {"text": message["caption"], "entities": []}
+
+
+def test_get_telegram_message_text_with_entities(
+    telegram_receiver, telegram_message_with_entities
+):
+    message = telegram_message_with_entities["message"]
+    message_text = telegram_receiver.get_message_text(message=message)
+
+    assert message_text == {"text": message["text"], "entities": message["entities"]}
+
+
+def test_process_text(telegram_receiver, telegram_message_with_entities):
+    live_post_block = construct_live_post_block(
+        message_id="1234", created=datetime.now()
+    )
+    text = telegram_receiver.get_message_text(
+        message=telegram_message_with_entities["message"]
+    )
+    telegram_receiver.process_text(live_post=live_post_block, message_text=text)
+
+    content = live_post_block["content"]
+    assert content[0].value == "This post contains different type of entities."
+    assert (
+        content[1].value
+        == "This is a regular link <a href='https://github.com/'>https://github.com/</a>."
+    )
+    assert content[2].value == "This is a hashtag entity #WagtailLiveBot"
+    assert (
+        content[3].value
+        == "This is a link_text <a href='https://github.com/wagtail'>wagtail</a>."
+    )
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+def test_get_file_path(telegram_receiver, mocker):
+    file_infos = {
+        "ok": True,
+        "result": {
+            "file_id": "some-id",
+            "file_unique_id": "some-id",
+            "file_size": 31254,
+            "file_path": "photos/file_1.jpg",
+        },
+    }
+    mocker.patch.object(
+        requests, "get", return_value=ResponseMock(ok=True, json_data=file_infos)
+    )
+    file_path = telegram_receiver.get_file_path(file_id="some_id")
+
+    assert file_path == "photos/file_1.jpg"
+
+
+def test_get_message_files_if_no_files(telegram_receiver, telegram_message):
+    message = telegram_message["message"]
+    message_files = telegram_receiver.get_message_files(message=message)
+
+    assert message_files == []
+
+
+def test_get_message_files_if_files(telegram_receiver, telegram_image_message, mocker):
+    message = telegram_image_message["message"]
+    photo = message["photo"][-1]
+    photo["file_path"] = file_path = "photos/file_1.jpg"
+
+    mocker.patch.object(
+        TelegramWebhookReceiver, "get_file_path", return_value=file_path
+    )
+    message_files = telegram_receiver.get_message_files(message=message)
+
+    assert message_files == [photo]
+
+
+def test_get_image_title(telegram_receiver):
+    image = {"file_path": "photos/file_1.jpg"}
+    image_title = telegram_receiver.get_image_title(image=image)
+
+    assert image_title == "file_1"
+
+
+def test_get_image_name(telegram_receiver):
+    image = {"file_path": "photos/file_1.jpg"}
+    image_name = telegram_receiver.get_image_name(image=image)
+
+    assert image_name == "file_1.jpg"
+
+
+def test_get_image_mimetype_jpg(telegram_receiver):
+    image = {"file_path": "photos/file_1.jpg"}
+    image_mimetype = telegram_receiver.get_image_mimetype(image=image)
+
+    assert image_mimetype == "jpeg"
+
+
+def test_get_image_mimetype_other_mimetypes(telegram_receiver):
+    image = {"file_path": "photos/file_1.other"}
+    image_mimetype = telegram_receiver.get_image_mimetype(image=image)
+
+    assert image_mimetype == "other"
+
+
+def test_get_image_dimensions(telegram_receiver, telegram_image_message):
+    message = telegram_image_message["message"]
+    image = message["photo"][-1]
+    image_dimensions = telegram_receiver.get_image_dimensions(image=image)
+
+    assert image_dimensions == (image["width"], image["height"])
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+def test_get_image_content(telegram_receiver, mocker):
+    class ResponseMock:
+        content = b""
+
+    mocker.patch.object(requests, "get", return_value=ResponseMock())
+    image_content = telegram_receiver.get_image_content(
+        image={"file_path": "photos/file_1.jpg"}
+    )
+
+    assert isinstance(image_content, ContentFile)
+    assert image_content.read() == b""
+
+
+def test_get_message_id_from_edited_message(telegram_receiver, telegram_edited_message):
+    message = telegram_edited_message["edited_message"]
+    message_id = telegram_receiver.get_message_id_from_edited_message(message=message)
+
+    assert message_id == telegram_receiver.get_message_id_from_message(message=message)
+
+
+def test_get_message_text_from_edited_message(
+    telegram_receiver, telegram_edited_message
+):
+    message = telegram_edited_message["edited_message"]
+    message_text = telegram_receiver.get_message_text_from_edited_message(
+        message=message
+    )
+
+    assert message_text == telegram_receiver.get_message_text(message=message)
+
+
+def test_get_message_files_from_edited_message(
+    telegram_receiver, telegram_edited_message
+):
+    message = telegram_edited_message["edited_message"]
+    message_files = telegram_receiver.get_message_files_from_edited_message(
+        message=message
+    )
+
+    assert message_files == telegram_receiver.get_message_files(message=message)
+
+
+def test_embed_message(telegram_receiver, telegram_embed_message, blog_page_factory):
+    live_post_block = construct_live_post_block(
+        message_id="1234", created=datetime.now()
+    )
+    text = telegram_receiver.get_message_text(message=telegram_embed_message["message"])
+    telegram_receiver.process_text(live_post=live_post_block, message_text=text)
+
+    content = live_post_block["content"]
+    assert content[0].value == "This is another test post."
+    assert content[1].value == "This post contains an embed."
+    assert content[2].block_type == EMBED
+    assert content[2].value.url == "https://www.youtube.com/watch?v=Cq3LOsf2kSY"
+
+
+def test_embed_message_2(
+    telegram_receiver, telegram_embed_message_2, blog_page_factory
+):
+    live_post_block = construct_live_post_block(
+        message_id="1234", created=datetime.now()
+    )
+    text = telegram_receiver.get_message_text(
+        message=telegram_embed_message_2["message"]
+    )
+    telegram_receiver.process_text(live_post=live_post_block, message_text=text)
+
+    content = live_post_block["content"]
+    assert content[0].value == "This is another test post."
+    assert content[1].value == (
+        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
+        "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>. "
+        "Some content here."
+    )
+    assert content[2].value == (
+        "Some content here. "
+        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
+        "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>"
+    )
+
+
+@pytest.mark.django_db
+def test_add_media_message(
+    telegram_receiver,
+    telegram_media_message_1,
+    telegram_media_message_2,
+    blog_page_factory,
+    mocker,
+):
+    page = blog_page_factory(channel_id="100")
+    assert len(page.live_posts) == 0
+
+    mocker.patch.object(
+        TelegramWebhookReceiver, "get_file_path", return_value="photos/file_1.jpg"
+    )
+    mocker.patch.object(
+        TelegramWebhookReceiver, "get_image_content", return_value=get_test_image_file()
+    )
+
+    telegram_receiver.dispatch_event(event=telegram_media_message_1)
+    page.refresh_from_db()
+
+    assert len(page.live_posts) == 1
+    post_content = page.live_posts[0].value["content"]
+    assert len(post_content) == 2
+    assert post_content[1].block_type == IMAGE
+
+    telegram_receiver.dispatch_event(event=telegram_media_message_2)
+    page.refresh_from_db()
+
+    assert len(page.live_posts) == 1
+    post_content = page.live_posts[0].value["content"]
+    assert len(post_content) == 3
+    assert post_content[2].block_type == IMAGE
+
+
+@pytest.mark.django_db
+def test_add_media_message_wrong_channel(
+    telegram_receiver,
+    telegram_media_message_1,
+    telegram_media_message_2,
+    blog_page_factory,
+    mocker,
+):
+    page = blog_page_factory(channel_id="100")
+    assert len(page.live_posts) == 0
+
+    mocker.patch.object(
+        TelegramWebhookReceiver, "get_file_path", return_value="photos/file_1.jpg"
+    )
+    mocker.patch.object(
+        TelegramWebhookReceiver, "get_image_content", return_value=get_test_image_file()
+    )
+
+    telegram_receiver.dispatch_event(event=telegram_media_message_1)
+    page.refresh_from_db()
+
+    assert len(page.live_posts) == 1
+    post_content = page.live_posts[0].value["content"]
+    assert len(post_content) == 2
+    assert post_content[1].block_type == IMAGE
+
+    telegram_media_message_2["message"]["chat"]["id"] = "99"
+    telegram_receiver.dispatch_event(event=telegram_media_message_2)
+    page.refresh_from_db()
+
+    assert len(page.live_posts) == 1
+    post_content = page.live_posts[0].value["content"]
+    assert len(post_content) == 2

--- a/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
+++ b/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
@@ -304,12 +304,12 @@ def test_process_text(telegram_receiver, telegram_message_with_entities):
     assert content[0].value == "This post contains different type of entities."
     assert (
         content[1].value
-        == "This is a regular link <a href='https://github.com/'>https://github.com/</a>."
+        == 'This is a regular link <a href="https://github.com/">https://github.com/</a>.'
     )
     assert content[2].value == "This is a hashtag entity #WagtailLiveBot"
     assert (
         content[3].value
-        == "This is a link_text <a href='https://github.com/wagtail'>wagtail</a>."
+        == 'This is a link_text <a href="https://github.com/wagtail">wagtail</a>.'
     )
 
 
@@ -459,13 +459,13 @@ def test_embed_message_2(
     content = live_post_block["content"]
     assert content[0].value == "This is another test post."
     assert content[1].value == (
-        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
+        '<a href="https://www.youtube.com/watch?v=Cq3LOsf2kSY">'
         "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>. "
         "Some content here."
     )
     assert content[2].value == (
         "Some content here. "
-        "<a href='https://www.youtube.com/watch?v=Cq3LOsf2kSY'>"
+        '<a href="https://www.youtube.com/watch?v=Cq3LOsf2kSY">'
         "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>"
     )
 

--- a/tests/wagtail_live/receivers/telegram/test_utils.py
+++ b/tests/wagtail_live/receivers/telegram/test_utils.py
@@ -1,0 +1,58 @@
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.test import override_settings
+
+from wagtail_live.adapters.telegram import (
+    get_base_telegram_url,
+    get_telegram_bot_token,
+    get_telegram_webhook_url,
+)
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+def test_get_telegram_bot_token():
+    assert get_telegram_bot_token() == "telegram-token"
+
+
+def test_get_telegram_bot_token_raises_error():
+    expected_err = (
+        "Specify TELEGRAM_BOT_TOKEN if you intend to use Telegram as input source."
+    )
+    get_telegram_bot_token.cache_clear()
+
+    with pytest.raises(ImproperlyConfigured, match=expected_err):
+        get_telegram_bot_token()
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+def test_get_base_telegram_url():
+    got = get_base_telegram_url()
+
+    assert got == "https://api.telegram.org/bottelegram-token/"
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+@override_settings(TELEGRAM_WEBHOOK_URL="www.webhook.com")
+def test_get_telegram_webhook_url():
+    got = get_telegram_webhook_url()
+
+    assert got == "www.webhook.com/wagtail_live/telegram/events/telegram-token/"
+
+
+@override_settings(TELEGRAM_BOT_TOKEN="telegram-token")
+@override_settings(TELEGRAM_WEBHOOK_URL="www.webhook.com/")
+def test_get_telegram_webhook_url_trailing_slash():
+    get_telegram_webhook_url.cache_clear()
+    got = get_telegram_webhook_url()
+
+    assert got == "www.webhook.com/wagtail_live/telegram/events/telegram-token/"
+
+
+def test_get_telegram_webhook_url_raises_error():
+    expected_err = (
+        "Specify TELEGRAM_WEBHOOK_URL if you intend to use Telegram as input source."
+    )
+    get_telegram_webhook_url.cache_clear()
+
+    with pytest.raises(ImproperlyConfigured, match=expected_err):
+        get_telegram_webhook_url()


### PR DESCRIPTION
PR to add Telegram webhook receiver.

**Current limitations**
When a message with multiple images is edited on Telegram, we only receive the edited message and the first photo of the message. This means that the other images of the message will be removed from the corresponding live post.

See #80 to find how to setup TelegramWebhookReceiver.