### PR TITLE
Sync live page with admin

### DIFF
--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,3 +1,16 @@
 # Settings
 
-All settings and their possible values listed here.
+Wagtail Live makes use of the following settings, in addition to Django and Wagtail's settings:
+
+## Synchronize live page with admin interface
+### `WAGTAIL_LIVE_SYNC_WITH_ADMIN`
+```python
+WAGTAIL_LIVE_SYNC_WITH_ADMIN = False
+```
+This setting controls the synchronization of a live page when it's modified in the admin interface.
+
+When `WAGTAIL_LIVE_SYNC_WITH_ADMIN` is `True` (default), the admin interface can be used as a way to publish instantly to a live page.
+
+When `WAGTAIL_LIVE_SYNC_WITH_ADMIN` is `False` , changes made in the admin interface aren't automatically/live published. 
+
+You can set the value of this setting to `False` if you don't intend to use the admin interface to publish/edit live posts. This will avoid making computations to track changes made in the admin interface.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -11,6 +11,6 @@ This setting controls the synchronization of a live page when it's modified in t
 
 When `WAGTAIL_LIVE_SYNC_WITH_ADMIN` is `True` (default), the admin interface can be used as a way to publish instantly to a live page.
 
-When `WAGTAIL_LIVE_SYNC_WITH_ADMIN` is `False` , changes made in the admin interface aren't automatically/live published. 
+When `WAGTAIL_LIVE_SYNC_WITH_ADMIN` is `False`, changes made in the admin interface aren't automatically/live published. 
 
 You can set the value of this setting to `False` if you don't intend to use the admin interface to publish/edit live posts. This will avoid making computations to track changes made in the admin interface.

--- a/src/wagtail_live/blocks.py
+++ b/src/wagtail_live/blocks.py
@@ -1,6 +1,5 @@
 """ Block types and block constructors are defined in this module."""
 
-from django.utils.timezone import now
 from wagtail.core.blocks import (
     BooleanBlock,
     CharBlock,
@@ -41,12 +40,6 @@ class LivePostBlock(StructBlock):
 
     class Meta:
         template = "wagtail_live/blocks/live_post.html"
-
-    def clean(self, value):
-        """Update modified field when a block is modified via the admin interface."""
-
-        value["modified"] = now()
-        return super().clean(value)
 
 
 def construct_text_block(text):

--- a/tests/wagtail_live/test_blocks.py
+++ b/tests/wagtail_live/test_blocks.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime
 
 import pytest
-from django.utils.timezone import now
 from wagtail.core.blocks import StreamValue, StructValue
 from wagtail.embeds.blocks import EmbedValue
 
@@ -46,27 +45,6 @@ def test_construct_live_post_block():
             "content": StreamValue(ContentBlock(), []),
         },
     )
-
-
-def test_update_modified_field():
-    live_post_block = construct_live_post_block(
-        message_id="1234",
-        created=datetime(1970, 1, 1, 12, 00),
-    )
-    assert live_post_block["modified"] is None
-
-    live_post_block["content"] = StreamValue(ContentBlock(), [("text", "Some text")])
-    live_post_block.block.clean(live_post_block)
-
-    last_modified = live_post_block["modified"]
-    diff = now() - last_modified
-    assert diff.total_seconds() == pytest.approx(0.0, abs=1)
-
-    live_post_block["content"] = StreamValue(
-        ContentBlock(), [("text", "Some text modified")]
-    )
-    live_post_block.block.clean(live_post_block)
-    assert live_post_block["modified"] > last_modified
 
 
 def test_add_block_to_live_post_structvalue():

--- a/tests/wagtail_live/test_models.py
+++ b/tests/wagtail_live/test_models.py
@@ -640,7 +640,7 @@ def test_save_live_page_edited_post(blog_page_factory):
 
         post = page.get_live_post_by_message_id(message_id="some-id")
 
-        # The value of the modified field for the first post shouldn't change
+        # The value of the modified field for the first post should change
         assert (
             page.get_live_post_by_message_id(message_id="some-id").value["modified"]
             == page.last_updated_at


### PR DESCRIPTION
Supersedes #83.

I added an extra optional setting `WAGTAIL_LIVE_SYNC_WITH_ADMIN`.
If that setting is True(default), modifications made on the admin will be synced with the live page.
If false, modifying a page in the admin interface will not send a signal.

The idea is to avoid the computations if one doesn't want to use this feature i.e syncing the admin interface and the live page.