### PR TITLE
Update tox env with Python 3.7 and Wagtail 2.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,17 @@ jobs:
     strategy:
       matrix:
         include:
+          # Wagtail 2.12
+          - toxenv: 'python3.7-django2.2-wagtail2.12'
+            python: 3.7
           - toxenv: 'python3.8-django2.2-wagtail2.12'
             python: 3.8
-          - toxenv: 'python3.9-django3.2-wagtail2.13'
+          # Wagtail 2.14
+          - toxenv: 'python3.7-django3.2-wagtail2.14'
+            python: 3.7
+          - toxenv: 'python3.8-django3.2-wagtail2.14'
+            python: 3.8
+          - toxenv: 'python3.9-django3.2-wagtail2.14'
             python: 3.9
     steps:
       - uses: actions/checkout@v2

--- a/src/wagtail_live/publishers/polling.py
+++ b/src/wagtail_live/publishers/polling.py
@@ -1,11 +1,11 @@
 import time
 from datetime import datetime, timezone
-from functools import cached_property
 
 from django.conf import settings
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404
 from django.urls import path
+from django.utils.functional import cached_property
 from django.views import View
 
 from wagtail_live.utils import (

--- a/src/wagtail_live/receivers/base.py
+++ b/src/wagtail_live/receivers/base.py
@@ -2,11 +2,11 @@
 
 import json
 import logging
-from functools import cached_property
 
 from django.http import HttpResponse, HttpResponseForbidden
 from django.urls import path
 from django.utils.decorators import method_decorator
+from django.utils.functional import cached_property
 from django.utils.timezone import now
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 skipsdist = True
 envlist = 
-    python3.8-django2.2-wagtail2.12
-    python3.9-django3.2-wagtail2.13
+    python{3.7,3.8}-django2.2-wagtail2.12
+    python{3.7,3.8,3.9}-django3.2-wagtail2.14
 
 basepython =
     python3.8: python3.8
@@ -14,7 +14,7 @@ commands = pytest --cov wagtail_live {posargs}
 extras = test
 deps =
     wagtail2.12: wagtail>=2.12,<2.13
-    wagtail2.13: wagtail>=2.13,<2.14
+    wagtail2.14: wagtail>=2.14,<2.15
     django2.2: django>=2.2,<2.3
     django3.2: django>=3.2,<3.3
 


### PR DESCRIPTION
Removed Wagtail 2.13 from the env list to save on the number of Python/Django/Wagtail combinations.