### PR TITLE
Some small mkdocs config changes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,8 @@ repo_name: wagtail/wagtail-live
 edit_uri: edit/main/docs/
 theme:
   name: 'material'
+  icon:
+    repo: fontawesome/brands/github
   features:
     - search.suggest
     - search.highlight

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,8 @@
 site_name: Wagtail Live
 site_url: https://wagtail.github.io/wagtail-live/
 repo_url: https://github.com/wagtail/wagtail-live
-edit_uri: blob/main/docs/
+repo_name: wagtail/wagtail-live
+edit_uri: edit/main/docs/
 theme:
   name: 'material'
   features:


### PR DESCRIPTION
1. Repo name
shows in the top right corner like this: 
![image](https://user-images.githubusercontent.com/13856515/129353862-98b276e3-9b23-4d53-983a-24d7a0244cd7.png)

2. Edit link now goes directly to the github editor.
3. Use github icon instead of the generic git icon.