### PR TITLE
Fix link rendering

### DIFF
--- a/src/wagtail_live/blocks.py
+++ b/src/wagtail_live/blocks.py
@@ -1,14 +1,17 @@
 """ Block types and block constructors are defined in this module."""
 
+from wagtail.admin.rich_text.converters.editor_html import EditorHTMLConverter
 from wagtail.core.blocks import (
     BooleanBlock,
     CharBlock,
     DateTimeBlock,
+    RichTextBlock,
     StreamBlock,
     StructBlock,
     StructValue,
-    TextBlock,
 )
+from wagtail.core.rich_text import RichText
+from wagtail.core.rich_text import features as feature_registry
 from wagtail.embeds.blocks import EmbedBlock
 from wagtail.images.blocks import ImageChooserBlock
 
@@ -16,7 +19,7 @@ from wagtail.images.blocks import ImageChooserBlock
 class ContentBlock(StreamBlock):
     """A block that represents a live post content."""
 
-    text = TextBlock(help_text="Text of the message")
+    text = RichTextBlock(help_text="Text of the message")
     image = ImageChooserBlock(help_text="Image of the message")
     embed = EmbedBlock(help_text="URL of the embed message")
 
@@ -50,10 +53,14 @@ def construct_text_block(text):
         text (str): Text to add
 
     Returns:
-        TextBlock: a TextBlock filled with the given text.
+        RichText: a TextBlock filled with the given text.
     """
 
-    return TextBlock().to_python(text)
+    # Make sure no malicious html is accepted
+    features = feature_registry.get_default_features()
+    cleaned_text = EditorHTMLConverter(features=features).whitelister.clean(text)
+
+    return RichTextBlock().to_python(cleaned_text)
 
 
 def construct_image_block(image):

--- a/src/wagtail_live/receivers/telegram/receivers.py
+++ b/src/wagtail_live/receivers/telegram/receivers.py
@@ -8,6 +8,7 @@ from wagtail_live.receivers.base import BaseMessageReceiver, WebhookReceiverMixi
 from wagtail_live.utils import is_embed
 
 from .utils import (
+    format_url,
     get_base_telegram_url,
     get_telegram_bot_token,
     get_telegram_webhook_url,
@@ -201,6 +202,7 @@ class TelegramWebhookReceiver(TelegramWebhookMixin, BaseMessageReceiver):
                 description = text[start:end]
 
             if url:
+                url = format_url(url)
                 link = f'<a href="{url}">{description}</a>'
                 text = text[:start] + link + text[end:]
 

--- a/src/wagtail_live/receivers/telegram/utils.py
+++ b/src/wagtail_live/receivers/telegram/utils.py
@@ -55,3 +55,13 @@ def get_base_telegram_url():
     """Returns the base URL to use when calling Telegram's API."""
 
     return f"https://api.telegram.org/bot{get_telegram_bot_token()}/"
+
+
+def format_url(url):
+    """Fixes telegram url format"""
+
+    # Prevent e.g. www.example.com from being interpreted as relative url
+    if not url.startswith("http") and not url.startswith("//"):
+        url = f"//{url}"
+
+    return url

--- a/tests/testapp/migrations/0001_initial.py
+++ b/tests/testapp/migrations/0001_initial.py
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
                                                 [
                                                     (
                                                         "text",
-                                                        wagtail.core.blocks.TextBlock(
+                                                        wagtail.core.blocks.RichTextBlock(
                                                             help_text="Text of the message"
                                                         ),
                                                     ),

--- a/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
@@ -400,10 +400,10 @@ def test_add_message(slack_receiver, slack_message, slack_page):
     assert len(content) == len(message_parts)
 
     assert content[0].block_type == TEXT
-    assert content[0].value == message_parts[0]
+    assert content[0].value.source == message_parts[0]
 
     assert content[-1].block_type == TEXT
-    assert content[-1].value == message_parts[-1]
+    assert content[-1].value.source == message_parts[-1]
 
 
 @pytest.mark.django_db
@@ -432,7 +432,7 @@ def test_change_message(
     message_added = BlogPage.objects.first().live_posts[-1]
     previous_id = message_added.id
     first_block = message_added.value["content"][0]
-    assert first_block.value == "This is another test post."
+    assert first_block.value.source == "This is another test post."
 
     # Edit the message
     edited_message = slack_edited_message["event"]
@@ -441,7 +441,7 @@ def test_change_message(
     message_added = BlogPage.objects.first().live_posts[-1]
     id_after_edit = message_added.id
     first_block = message_added.value["content"][0]
-    assert first_block.value == "This is another test post that has been edited."
+    assert first_block.value.source == "This is another test post that has been edited."
 
     # ID is preserved.
     assert previous_id == id_after_edit
@@ -457,7 +457,7 @@ def test_change_message_wrong_channel(
     message_added = BlogPage.objects.first().live_posts[-1]
     previous_id = message_added.id
     first_block = message_added.value["content"][0]
-    assert first_block.value == "This is another test post."
+    assert first_block.value.source == "This is another test post."
 
     edited_message = slack_edited_message["event"]
     edited_message["channel"] = "not_slack_channel"
@@ -466,7 +466,7 @@ def test_change_message_wrong_channel(
     message_added = BlogPage.objects.first().live_posts[-1]
     id_after_edit = message_added.id
     first_block = message_added.value["content"][0]
-    assert first_block.value == "This is another test post."
+    assert first_block.value.source == "This is another test post."
 
     assert previous_id == id_after_edit
 

--- a/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
+++ b/tests/wagtail_live/receivers/telegram/test_telegramwebhookreceiver.py
@@ -5,6 +5,7 @@ import requests
 from django.core.files.base import ContentFile
 from django.test import override_settings
 from django.urls import resolve, reverse
+from wagtail.core.rich_text import RichText
 
 from tests.utils import get_test_image_file, reload_urlconf
 from wagtail_live.blocks import construct_live_post_block
@@ -301,14 +302,14 @@ def test_process_text(telegram_receiver, telegram_message_with_entities):
     telegram_receiver.process_text(live_post=live_post_block, message_text=text)
 
     content = live_post_block["content"]
-    assert content[0].value == "This post contains different type of entities."
+    assert content[0].value.source == "This post contains different type of entities."
     assert (
-        content[1].value
+        content[1].value.source
         == 'This is a regular link <a href="https://github.com/">https://github.com/</a>.'
     )
-    assert content[2].value == "This is a hashtag entity #WagtailLiveBot"
+    assert content[2].value.source == "This is a hashtag entity #WagtailLiveBot"
     assert (
-        content[3].value
+        content[3].value.source
         == 'This is a link_text <a href="https://github.com/wagtail">wagtail</a>.'
     )
 
@@ -439,8 +440,8 @@ def test_embed_message(telegram_receiver, telegram_embed_message, blog_page_fact
     telegram_receiver.process_text(live_post=live_post_block, message_text=text)
 
     content = live_post_block["content"]
-    assert content[0].value == "This is another test post."
-    assert content[1].value == "This post contains an embed."
+    assert content[0].value.source == "This is another test post."
+    assert content[1].value.source == "This post contains an embed."
     assert content[2].block_type == EMBED
     assert content[2].value.url == "https://www.youtube.com/watch?v=Cq3LOsf2kSY"
 
@@ -457,13 +458,13 @@ def test_embed_message_2(
     telegram_receiver.process_text(live_post=live_post_block, message_text=text)
 
     content = live_post_block["content"]
-    assert content[0].value == "This is another test post."
-    assert content[1].value == (
+    assert content[0].value.source == "This is another test post."
+    assert content[1].value.source == (
         '<a href="https://www.youtube.com/watch?v=Cq3LOsf2kSY">'
         "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>. "
         "Some content here."
     )
-    assert content[2].value == (
+    assert content[2].value.source == (
         "Some content here. "
         '<a href="https://www.youtube.com/watch?v=Cq3LOsf2kSY">'
         "https://www.youtube.com/watch?v=Cq3LOsf2kSY</a>"

--- a/tests/wagtail_live/receivers/test_basemessagereceiver.py
+++ b/tests/wagtail_live/receivers/test_basemessagereceiver.py
@@ -87,17 +87,17 @@ def test_process_text(base_receiver, blog_page_factory):
     post_content = live_post.value["content"]
 
     assert post_content[0].block_type == TEXT
-    assert post_content[0].value == "Live Post Title"
+    assert post_content[0].value.source == "Live Post Title"
 
     assert post_content[1].block_type == TEXT
-    assert post_content[1].value == "Check out Wagtail"
+    assert post_content[1].value.source == "Check out Wagtail"
 
     assert post_content[2].block_type == EMBED
     assert isinstance(post_content[2].value, EmbedValue)
     assert post_content[2].value.url == valid_embed
 
     assert post_content[-1].block_type == TEXT
-    assert post_content[-1].value == "Have fun!"
+    assert post_content[-1].value.source == "Have fun!"
 
 
 @pytest.mark.django_db

--- a/tests/wagtail_live/receivers/test_webappreceiver.py
+++ b/tests/wagtail_live/receivers/test_webappreceiver.py
@@ -207,10 +207,10 @@ def test_add_message(blog_page_factory, webapp_receiver, message):
     assert len(content) == len(message_parts)
 
     assert content[0].block_type == TEXT
-    assert content[0].value == message_parts[0].strip()
+    assert content[0].value.source == message_parts[0].strip()
 
     assert content[-1].block_type == TEXT
-    assert content[-1].value == message_parts[-1].strip()
+    assert content[-1].value.source == message_parts[-1].strip()
 
 
 @pytest.mark.django_db
@@ -240,7 +240,7 @@ def test_change_message(blog_page_factory, webapp_receiver, message):
     assert len(content) == 1
 
     first_block = content[0]
-    assert first_block.value == "Edited"
+    assert first_block.value.source == "Edited"
 
 
 @pytest.mark.django_db
@@ -258,8 +258,8 @@ def test_change_message_wrong_channel(blog_page_factory, webapp_receiver, messag
 
     # live post content shouldn't change
     assert len(content) == 2
-    assert content[0].value == "Some content."
-    assert content[-1].value == "More content here."
+    assert content[0].value.source == "Some content."
+    assert content[-1].value.source == "More content here."
 
 
 @pytest.mark.django_db

--- a/tests/wagtail_live/test_blocks.py
+++ b/tests/wagtail_live/test_blocks.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import pytest
 from wagtail.core.blocks import StreamValue, StructValue
+from wagtail.core.rich_text import RichText
 from wagtail.embeds.blocks import EmbedValue
 
 from wagtail_live.blocks import (
@@ -19,7 +20,7 @@ from wagtail_live.receivers.base import TEXT
 
 def test_construct_text_block():
     text_block = construct_text_block(text="Some text")
-    assert text_block == "Some text"
+    assert text_block.source == "Some text"
 
 
 def test_construct_embed_block():
@@ -57,7 +58,10 @@ def test_add_block_to_live_post_structvalue():
     add_block_to_live_post(TEXT, text_block, live_post)
 
     assert isinstance(live_post, StructValue)
-    assert live_post["content"] == StreamValue(ContentBlock(), [("text", "Some text")])
+    setattr(RichText, "__eq__", lambda self, other: self.source == other.source)
+    assert live_post["content"] == StreamValue(
+        ContentBlock(), [("text", RichText("Some text"))]
+    )
 
 
 @pytest.mark.django_db
@@ -84,8 +88,9 @@ def test_add_block_to_live_post_streamchild(blog_page_factory):
     add_block_to_live_post(TEXT, text_block, live_post)
 
     assert isinstance(live_post, StreamValue.StreamChild)
+    setattr(RichText, "__eq__", lambda self, other: self.source == other.source)
     assert live_post.value["content"] == StreamValue(
-        ContentBlock(), [("text", "Some text")]
+        ContentBlock(), [("text", RichText("Some text"))]
     )
 
 


### PR DESCRIPTION
This fixes the issue of links not being clickable by adding support for rich text content. Links were currently rendered as plain text, because a TextBlock was used instead of a RichTextBlock, which will render plain text by default. Not fully sure if this is the way we want to go, as it also allows html to be entered from the receivers. The html is whitelisted according to the default rules specified for the project.

Tests are also converted to expect rich text from being used instead of normal text. Since RichText objects unfortunately don't support equality testing on text content, the tests are changed to test for the source value of the RichText instead of the RichText object.

Another small issue with Telegram links was fixed were links without protocol (e.g. www.example.com instead of https://www.example.com) were interpreted as relative urls to the page where they were rendered. To fix this, two slashes are prepended to the url, so that the browser can figure out the protocol by itself.