### PR TITLE
Store strong references to websocket publishers

### DIFF
--- a/src/wagtail_live/apps.py
+++ b/src/wagtail_live/apps.py
@@ -16,4 +16,9 @@ class WagtailLiveConfig(AppConfig):
         if issubclass(live_publisher, BaseWebsocketPublisher):
             from wagtail_live.signals import live_page_update
 
-            live_page_update.connect(live_publisher(), weak=False, dispatch_uid="live_publisher")
+            # Set`weak=False` to avoid the publisher being garbage collected.
+            # See:
+            # https://docs.djangoproject.com/en/3.2/topics/signals/#django.dispatch.Signal.connect
+            live_page_update.connect(
+                live_publisher(), weak=False, dispatch_uid="live_publisher"
+            )

--- a/tests/testapp/publishers.py
+++ b/tests/testapp/publishers.py
@@ -2,7 +2,8 @@ from wagtail_live.publishers.websocket import BaseWebsocketPublisher
 
 
 class DummyWebsocketPublisher(BaseWebsocketPublisher):
-    pass
+    def publish(self, channel_id, renders, removals):
+        pass
 
 
 class DummyPublisher:


### PR DESCRIPTION
Both @allcaps  and I have set up a project using PieSocket publisher.

The publisher works the first times and suddenly stops working.

This is due to the fact that Django store weak references to signal listeners. See [here](https://docs.djangoproject.com/en/3.2/topics/signals/#django.dispatch.Signal.connect). Since our live publishers aren't referenced elsewhere in the code, they might get garbage collected hence the bug.

This PR fixes that.