### PR TITLE
Fix richtext blocks comparison

### DIFF
--- a/src/wagtail_live/blocks.py
+++ b/src/wagtail_live/blocks.py
@@ -183,8 +183,8 @@ def compare_live_posts_values(first_post_value, second_post_value):
         first_value = first_item.value
         second_value = second_item.value
         if isinstance(first_value, rich_text.RichText):
-            first_value = first_value.source
-            second_value = second_value.source
+            first_value = rich_text.get_text_for_indexing(first_value.source)
+            second_value = rich_text.get_text_for_indexing(second_value.source)
         elif isinstance(first_value, EmbedValue):
             first_value = first_value.url
             second_value = second_value.url


### PR DESCRIPTION
Use [`get_text_for_indexing`](https://github.com/wagtail/wagtail/blob/3e64deb1ac34c4d21c36156f93624e30ee7e6e71/wagtail/core/rich_text/__init__.py#L41) for rich text comparison instead of comparing the `source` [here](https://github.com/wagtail/wagtail-live/blob/d30ab6ca8de29665fecffeb9a315de8ce309e7cf/src/wagtail_live/blocks.py#L186-L187).