### PR TITLE
Set content-type to 'plain/text' on Slack URL verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix: Set content-type to 'plain/text' as expected by Slack API on url verification
 
 ## [1.0.0] - 2021-10-28
 - Initial release

--- a/src/wagtail_live/receivers/slack/receivers.py
+++ b/src/wagtail_live/receivers/slack/receivers.py
@@ -33,7 +33,7 @@ class SlackWebhookMixin(WebhookReceiverMixin):
 
         payload = json.loads(request.body.decode("utf-8"))
         if payload["type"] == "url_verification":
-            return HttpResponse(payload["challenge"])
+            return HttpResponse(payload["challenge"], content_type="plain/text")
         return super().post(request, *args, **kwargs)
 
     @staticmethod

--- a/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
@@ -113,6 +113,10 @@ class TestPostSlackEventsAPIReceiver:
         )
 
         assert response.status_code == 200
+        if not hasattr(response, "headers"):  # Django < 2.2
+            assert response._headers["content-type"][1] == "plain/text"
+        else:
+            assert response.headers["content-type"] == "plain/text"
         assert "challenge_token" in response.content.decode()
 
     def test_post_request_verification_error(self, slack_receiver, client):


### PR DESCRIPTION
This PR sets the content type of the URL verification response to 'plain/text' instead of the default ('text/html') to avoid errors as described on #139.