### PR TITLE
Gracefully handle error when deleting a missing message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Fix: Set content-type to 'plain/text' as expected by Slack API on url verification
+- Gracefully handle error when deleting a message that is no longer present on a live page
 
 ## [1.0.0] - 2021-10-28
 - Initial release

--- a/src/wagtail_live/receivers/base.py
+++ b/src/wagtail_live/receivers/base.py
@@ -412,7 +412,15 @@ class BaseMessageReceiver:
             return
 
         message_id = self.get_message_id_from_edited_message(message=message)
-        live_page.delete_live_post(message_id=message_id)
+        try:
+            live_page.delete_live_post(message_id=message_id)
+        except KeyError:
+            logger.warning(
+                f"Couldn't delete message with id={message_id}.\n"
+                "This may be due for 2 reasons:\n"
+                "1- The post hasn't been saved on the live page.\n"
+                "2- The post has been deleted in the admin interface.\n"
+            )
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
+++ b/tests/wagtail_live/receivers/slack/test_slackeventsapireceiver.py
@@ -496,6 +496,23 @@ def test_delete_message(
 
 
 @pytest.mark.django_db
+def test_delete_unsaved_message(
+    slack_receiver, slack_deleted_message, slack_page, caplog
+):
+    deleted_message = slack_deleted_message["event"]
+    slack_receiver.delete_message(message=deleted_message)
+
+    message_id = slack_receiver.get_message_id_from_edited_message(deleted_message)
+    expected = (
+        f"Couldn't delete message with id={message_id}.\n"
+        "This may be due for 2 reasons:\n"
+        "1- The post hasn't been saved on the live page.\n"
+        "2- The post has been deleted in the admin interface.\n"
+    )
+    assert caplog.messages[0] == expected
+
+
+@pytest.mark.django_db
 def test_delete_message_wrong_channel(
     slack_receiver, slack_embed_message, slack_deleted_message, slack_page
 ):


### PR DESCRIPTION
This PR aims to fix issue #141.

When a `KeyError` is raised when deleting a missing message, warn the user and return a 200 response.