### PR TITLE
Add possibility to use secure WebSocket connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Fix: Set content-type to 'plain/text' as expected by Slack API on url verification
 - Gracefully handle error when deleting a message that is no longer present on a live page
+- Add ability for publishers to use secure WebSocket connections.
 
 ## [1.0.0] - 2021-10-28
 - Initial release

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -78,6 +78,11 @@ See [Configuring a publisher](../getting_started/tutorial.md#configuring-a-publi
 |------------------------------------------------------------------------|----------|---------|
 | Server port for websocket publishers based on starlette, websockets... | No       | 8765    |
 
+### `WAGTAIL_LIVE_USE_SECURE_WS_CONNECTION`
+| Description                                                                                                                                                                                                                    	| Required 	| Default 	|
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|----------	|---------	|
+| Determines if a publisher should use a secure WebSocket connection.<br>Set this to `True` if your site is deployed over `https` since browsers don't allow insecure WebSocket connections (ws) from secure websites (https). 	| No       	| False   	|
+
 ## Synchronize live page with admin interface
 ### `WAGTAIL_LIVE_SYNC_WITH_ADMIN`
 | Description                                                                                             | Required | Default |

--- a/src/wagtail_live/static/wagtail_live/js/websocket/websocket.js
+++ b/src/wagtail_live/static/wagtail_live/js/websocket/websocket.js
@@ -1,6 +1,8 @@
+const scheme = useSecureWsConnection === true ? "wss" : "ws";
+
 class WebsocketPublisher {
     /**
-     * Initializes and pens a new websocket connection with server side 
+     * Initializes and opens a new websocket connection with server side 
      * or a real-time message service.
      * @constructor
      * @param {String} baseURL - baseURL to use for websocket connections.
@@ -38,7 +40,7 @@ class WebsocketPublisher {
 class GenericWebsocketPublisher extends WebsocketPublisher {
     initialize_websocket_connection() {
         this.websocket = new WebSocket(
-            `ws://${this.baseURL}/ws/channel/${channelID}/`
+            `${scheme}://${this.baseURL}/ws/channel/${channelID}/`
         );
     }
 

--- a/src/wagtail_live/templates/wagtail_live/websocket/django_channels.html
+++ b/src/wagtail_live/templates/wagtail_live/websocket/django_channels.html
@@ -1,4 +1,6 @@
 {% load static %}
 
+{% include "wagtail_live/websocket/websocket.html" %}
+
 <script src="{% static 'wagtail_live/js/websocket/websocket.js' %}"></script>
 <script src="{% static 'wagtail_live/js/websocket/django_channels.js' %}"></script>

--- a/src/wagtail_live/templates/wagtail_live/websocket/piesocket.html
+++ b/src/wagtail_live/templates/wagtail_live/websocket/piesocket.html
@@ -1,5 +1,7 @@
 {% load wagtail_live_tags static %}
 
+{% include "wagtail_live/websocket/websocket.html" %}
+
 <script>
     const piesocketApiKey = "{% piesocket_api_key %}"
     const piesocketEndpoint = "{% piesocket_endpoint %}"

--- a/src/wagtail_live/templates/wagtail_live/websocket/starlette.html
+++ b/src/wagtail_live/templates/wagtail_live/websocket/starlette.html
@@ -1,5 +1,7 @@
 {% load static wagtail_live_tags %}
 
+{% include "wagtail_live/websocket/websocket.html" %}
+
 <script>
     const serverHost = "{% get_server_host %}";
     const serverPort = "{% get_server_port %}";

--- a/src/wagtail_live/templates/wagtail_live/websocket/websocket.html
+++ b/src/wagtail_live/templates/wagtail_live/websocket/websocket.html
@@ -1,0 +1,5 @@
+{% load wagtail_live_tags %}
+
+<script>
+    const useSecureWsConnection = JSON.parse("{% use_secure_ws_connection %}".toLowerCase());
+</script>

--- a/src/wagtail_live/templates/wagtail_live/websocket/websockets.html
+++ b/src/wagtail_live/templates/wagtail_live/websocket/websockets.html
@@ -1,5 +1,7 @@
 {% load static wagtail_live_tags %}
 
+{% include "wagtail_live/websocket/websocket.html" %}
+
 <script>
     const serverHost = "{% get_server_host %}";
     const serverPort = "{% get_server_port %}";

--- a/src/wagtail_live/templatetags/wagtail_live_tags.py
+++ b/src/wagtail_live/templatetags/wagtail_live_tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.conf import settings
 
 from wagtail_live.publishers.piesocket import (
     get_piesocket_api_key,
@@ -7,6 +8,11 @@ from wagtail_live.publishers.piesocket import (
 from wagtail_live.publishers.utils import get_live_server_host, get_live_server_port
 
 register = template.Library()
+
+
+@register.simple_tag
+def use_secure_ws_connection():
+    return getattr(settings, "WAGTAIL_LIVE_USE_SECURE_WS_CONNECTION", False)
 
 
 @register.simple_tag

--- a/tests/wagtail_live/test_wagtail_live_tags.py
+++ b/tests/wagtail_live/test_wagtail_live_tags.py
@@ -9,6 +9,15 @@ from wagtail_live.publishers.piesocket.utils import (
 context = Context({})
 
 
+def test_use_secure_ws_connection():
+    to_render = Template(
+        "{% load wagtail_live_tags %}" "{% use_secure_ws_connection %}"
+    )
+    rendered = to_render.render(context)
+
+    assert rendered == "False"  # Default value
+
+
 def test_get_server_host_tag():
     to_render = Template("{% load wagtail_live_tags %}" "{% get_server_host %}")
     rendered = to_render.render(context)


### PR DESCRIPTION
The goal of this PR is to allow publishers of liveblogs running over HTTPS to use secure WebSocket connections.

Fixes #143.